### PR TITLE
bug fix on manylinux2010

### DIFF
--- a/src/libread.f90
+++ b/src/libread.f90
@@ -47,11 +47,10 @@ contains
    call check_argcv()
  end subroutine check_argcv_c
 
-subroutine get_labels_c(labels_out, ncol) bind(c, name='get_labels')
+subroutine get_labels_c(labels_out, ncol) bind(c, name='getlabels')
   integer(c_int),          intent(in)  :: ncol
   character(kind=c_char),  intent(out) :: labels_out(lenlabel, ncol)
   character(len=lenlabel)    :: temp_string
-  character(kind=c_char)     :: temp_cstring
   integer :: i,j
 
   call get_labels


### PR DESCRIPTION
get_labels, distinguished bind C name from a fortran subroutine with same name.
Prevents: Fortran runtime error: Recursive call to nonrecursive procedure 'get_labels_c'